### PR TITLE
nginxなどrouting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 #### Quick Start
 `docker-compose up`してdockerに割り当てられているipでアクセス
 
-`192.168.99.100:8080`をデフォルトにしているので、Macなどで起動する場合は`Myapp.rb`のdb_connectと`conf/nginx.conf`の`192.168.99.100`の部分を変更する
+`192.168.99.100:8080`をデフォルトにしているので、Macなどで起動する場合(dockerのデフォルトipが`localhost`)は`docker-compose.yml`の`192.168.99.100`の部分(`docker_ip`と`DOCKER_IP`を変更する)
 
 `192.168.99.100:4567`でnginx経由ではなく直接アクセス可
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -33,18 +33,18 @@ http {
     gzip  on;
 
     upstream latestgram{
-        server 192.168.99.100:4567;
+        server ${DOCKER_IP}:4567;
     }
 
     server {
         listen       8080;
-        server_name  192.168.99.100;
+        server_name  ${DOCKER_IP};
         root  /var/www/html;
 
-        proxy_set_header Host               192.168.99.100:8080;
+        proxy_set_header Host               ${DOCKER_IP}:8080;
         proxy_set_header X-Forwarded-For    http://latestgram:4567;
-        proxy_set_header X-Forwarded-Host   192.168.99.100:8080;
-        proxy_set_header X-Forwarded-Server 192.168.99.100:8080;
+        proxy_set_header X-Forwarded-Host   ${DOCKER_IP}:8080;
+        proxy_set_header X-Forwarded-Server ${DOCKER_IP}:8080;
 
         #charset koi8-r;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,20 @@ services:
       - db
       - nginx
     command: bundle exec ruby myapp.rb -o 0.0.0.0
+    extra_hosts:
+      #- "docker_ip:${DOCKER_HOST}"
+      - "docker_ip:192.168.99.100"
 
   nginx:
     image: nginx:latest
     volumes: 
-      - ./conf/nginx.conf:/etc/nginx/nginx.conf
+      - ./conf/nginx.conf:/etc/nginx/conf.d/default.conf.template
       - ./public:/var/www/html
     ports:
       - "8080:8080"
+    environment:
+        - DOCKER_IP=192.168.99.100
+    command: /bin/bash -c "envsubst '$$DOCKER_IP' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
 
   db:
     image: mysql:latest

--- a/myapp.rb
+++ b/myapp.rb
@@ -5,6 +5,7 @@ require 'mysql2-cs-bind'
 require 'fileutils'
 require 'rack-flash'
 require 'openssl'
+require "socket"
 
 class MyApp < Sinatra::Base
   set :bind, '0.0.0.0'
@@ -19,7 +20,7 @@ class MyApp < Sinatra::Base
     def db_connect()
       client = Mysql2::Client.new(
         #:host     => 'localhost',
-        :host     => '192.168.99.100',
+        :host     => TCPSocket.gethostbyname("docker_ip").last,
         #:port     => '3306',
         :username => 'root',
         :password => '',


### PR DESCRIPTION
Mac上で起動する場合など、dockerのホストIDが変化した時に`docker-compose.yml`だけ書き換えればいいように調整

### nginx
#7 
https://qiita.com/minamijoyo/items/63ae57b99d4a4c5d7987
を参考に
```yml
nginx:
     image: nginx:latest
     volumes: 
-      - ./conf/nginx.conf:/etc/nginx/nginx.conf
+      - ./conf/nginx.conf:/etc/nginx/conf.d/default.conf.template
       - ./public:/var/www/html
     ports:
       - "8080:8080"
+    environment:
+        - DOCKER_IP=192.168.99.100
+    command: /bin/bash -c "envsubst '$$DOCKER_IP' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
 
   db:
     image: mysql:latest
```
これでdocker_compose.ymlのipを変えれば、nginx.confに反映される！

### db(MySQL)
```yml
+    extra_hosts:
+      #- "docker_ip:${DOCKER_HOST}"
+      - "docker_ip:192.168.99.100"

```
して`myapp.rb`のDB接続部分を書き換え

```ruby
require "socket"

     def db_connect()
       client = Mysql2::Client.new(
         #:host     => 'localhost',
-         :host     => '192.168.99.100',
+         :host     => TCPSocket.gethostbyname("docker_ip").last,
```