### PR TITLE
docker_for_macでも動くように調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 #### Quick Start
 `docker-compose up`してdockerに割り当てられているipでアクセス
 
-`192.168.99.100:8080`をデフォルトにしているので、Macなどで起動する場合(dockerのデフォルトipが`localhost`)は`docker-compose.yml`の`192.168.99.100`の部分(`docker_ip`と`DOCKER_IP`を変更する)
+`192.168.99.100:8080`をデフォルトにしているので、Macなどで起動する場合(dockerのデフォルトipが`localhost`)は`docker-compose.yml`の`192.168.99.100`の部分(`DOCKER_IP`)を変更する
 
 `192.168.99.100:4567`でnginx経由ではなく直接アクセス可
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -33,7 +33,7 @@ http {
     gzip  on;
 
     upstream latestgram{
-        server ${DOCKER_IP}:4567;
+        server web:4567;
     }
 
     server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,7 @@ services:
       - "4567:4567"
     depends_on:
       - db
-      - nginx
     command: bundle exec ruby myapp.rb -o 0.0.0.0
-    extra_hosts:
-      #- "docker_ip:${DOCKER_HOST}"
-      - "docker_ip:192.168.99.100"
 
   nginx:
     image: nginx:latest
@@ -22,8 +18,12 @@ services:
       - ./public:/var/www/html
     ports:
       - "8080:8080"
+    depends_on:
+      - web
     environment:
-        - DOCKER_IP=192.168.99.100
+        #- DOCKER_IP=192.168.99.100
+        #- DOCKER_IP=127.0.0.1
+        - DOCKER_IP=127.0.0.1
     command: /bin/bash -c "envsubst '$$DOCKER_IP' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
 
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ services:
       - web
     environment:
         #- DOCKER_IP=192.168.99.100
-        #- DOCKER_IP=127.0.0.1
-        - DOCKER_IP=127.0.0.1
+        - DOCKER_IP=localhost
     command: /bin/bash -c "envsubst '$$DOCKER_IP' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
 
   db:

--- a/myapp.rb
+++ b/myapp.rb
@@ -5,7 +5,6 @@ require 'mysql2-cs-bind'
 require 'fileutils'
 require 'rack-flash'
 require 'openssl'
-require "socket"
 
 class MyApp < Sinatra::Base
   set :bind, '0.0.0.0'
@@ -19,9 +18,8 @@ class MyApp < Sinatra::Base
   helpers do
     def db_connect()
       client = Mysql2::Client.new(
-        #:host     => 'localhost',
-        :host     => TCPSocket.gethostbyname("docker_ip").last,
-        #:port     => '3306',
+        :host     => 'db',
+        :port     => '3306',
         :username => 'root',
         :password => '',
         :database => 'latestgram',


### PR DESCRIPTION
`docker for mac` だと現状動かないので調整
docker for mac ではコンテナ→コンテナのアクセスipとコンテナ→ホストのアクセスipが違うらしいので、docker-compose.ymlに書いてあるサービス名でアクセスする（バージョン２以降だとdockerが自動で割り当ててくれる）

### myapp.rb, nginx
環境変数用いる方法ではなく、サービス名でMySQLにアクセスする

### docker-compose
必要なくなったものを削除