### PR TITLE
docker-compose にnginx.conf用のdockerのhost ip 書かなくてもいいようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 最新50件の画像を表示する
 
 #### Quick Start
-`docker-compose up`してdockerに割り当てられているipでアクセス
+`docker-compose up`してdockerに割り当てられているip(docker_ipとする)の8080ポートでアクセス`docker_ip:8080`
 
-`192.168.99.100:8080`をデフォルトにしているので、Macなどで起動する場合(dockerのデフォルトipが`localhost`)は`docker-compose.yml`の`192.168.99.100`の部分(`DOCKER_IP`)を変更する
+例）docker for mac なら `localhost:8080`
 
-`192.168.99.100:4567`でnginx経由ではなく直接アクセス可
+`docker_ip:4567`でnginx経由ではなく直接アクセス可
 
 ## 構成
 * top

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -38,13 +38,13 @@ http {
 
     server {
         listen       8080;
-        server_name  ${DOCKER_IP};
+        server_name  $host;
         root  /var/www/html;
 
-        proxy_set_header Host               ${DOCKER_IP}:8080;
+        proxy_set_header Host               $host:8080;
         proxy_set_header X-Forwarded-For    http://latestgram:4567;
-        proxy_set_header X-Forwarded-Host   ${DOCKER_IP}:8080;
-        proxy_set_header X-Forwarded-Server ${DOCKER_IP}:8080;
+        proxy_set_header X-Forwarded-Host   $host:8080;
+        proxy_set_header X-Forwarded-Server $host:8080;
 
         #charset koi8-r;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,6 @@ services:
       - "8080:8080"
     depends_on:
       - web
-    environment:
-        #- DOCKER_IP=192.168.99.100
-        - DOCKER_IP=localhost
-    command: /bin/bash -c "envsubst '$$DOCKER_IP' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
 
   db:
     image: mysql:latest


### PR DESCRIPTION
色々試行錯誤したが
`nginx.conf`には$hostという値が使えるため、これを用いることでdocker のホストipが変わっても統一的にアクセスできる
http://nginx.org/en/docs/http/ngx_http_core_module.html#variables
![image](https://user-images.githubusercontent.com/18478417/38504371-786fffde-3c4f-11e8-84f1-340bca0b0a02.png)
