### PR TITLE
db設定調整

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     depends_on:
       - db
     command: bundle exec ruby myapp.rb -o 0.0.0.0
+    environment:
+      - "TZ=Asia/Tokyo"
 
   nginx:
     image: nginx:latest
@@ -22,13 +24,13 @@ services:
       - web
 
   db:
-    image: mysql:latest
+    build: ./sql
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
       MYSQL_DATABASE: "latestgram"
       MYSQL_USER: "root"
+      TZ: "Asia/Tokyo"
     volumes:
       - ./sql:/docker-entrypoint-initdb.d
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
     ports:
       - "3306:3306"

--- a/myapp.rb
+++ b/myapp.rb
@@ -24,7 +24,7 @@ class MyApp < Sinatra::Base
         :password => '',
         :database => 'latestgram',
         :encoding => 'utf8mb4',
-        :datatbase_timezone => :local
+        :datatbase_timezone => "Asia/Tokyo"
       )
       return client
     end

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:latest
+
+ADD ./my.cnf /etc/mysql/my.cnf
+
+RUN chmod 644 /etc/mysql/my.cnf

--- a/sql/my.cnf
+++ b/sql/my.cnf
@@ -1,0 +1,7 @@
+[mysql]
+default-character-set=utf8mb4
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+[client]
+default-character-set=utf8mb4


### PR DESCRIPTION
https://qiita.com/waterada/items/1dbf6a977611e0e8f5c8
これによると、docker-compose.ymlでmy.cnfをマウントするのはNG！（windowsの場合）
* windows上のファイルは777と認識される
* 777のパーミッションの設定ファイルをmysqlが認識しない

ええ・・・キツイ。
https://blog.local-c.com/archives/1984
上記を参考に新規にmysqlのdockerfile作ってその中でADDしてchmodすることに

## タイムゾーンがUTCになっているので変更
注意！webの方の設定も変えましょう

## 文字コードの設定
🍣＝🍺問題とハハ＝パパ問題が解決できていなかったので
http://blog.kamipo.net/entry/2015/03/23/093052
上記を参考に
collation-server=utf8mb4_bin
とする